### PR TITLE
feat(renderer): show toast for timed events

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -14,6 +14,11 @@ const api = {
     return () => ipcRenderer.removeListener(IpcChannels.UI_TOAST, h);
   },
 
+  // Közvetlen toast küldése a rendererben
+  toast: (msg: { message: string; variant?: "default"|"error"|"success"|"warning"|"info" }) => {
+    ipcRenderer.emit(IpcChannels.UI_TOAST, undefined, msg);
+  },
+
   // Lifecycle pushok – csak ha külön is hallgatnád
   onLifecycle: (service: "t1"|"t2"|"t3", cb: (ev: LifecycleEvent) => void) => {
     const ch = service === "t1" ? IpcChannels.T1_LIFECYCLE : service === "t2" ? IpcChannels.T2_LIFECYCLE : IpcChannels.T3_LIFECYCLE;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,9 +41,9 @@ const Main: React.FC = () => {
     window.api.registerPush(IpcChannels.T1_TIMED, scope);
     window.api.registerPush(IpcChannels.T2_TIMED, scope);
     window.api.registerPush(IpcChannels.T3_TIMED, scope);
-    const off1 = window.api.onTimed("t1", p => console.log("MAIN timed t1:", p));
-    const off2 = window.api.onTimed("t2", p => console.log("MAIN timed t2:", p));
-    const off3 = window.api.onTimed("t3", p => console.log("MAIN timed t3:", p));
+    const off1 = window.api.onTimed("t1", p => window.api.toast({ message: `MAIN timed t1: ${p.info}` }));
+    const off2 = window.api.onTimed("t2", p => window.api.toast({ message: `MAIN timed t2: ${p.info}` }));
+    const off3 = window.api.onTimed("t3", p => window.api.toast({ message: `MAIN timed t3: ${p.info}` }));
     return () => {
       window.api.unregisterPush(IpcChannels.T1_TIMED, scope);
       window.api.unregisterPush(IpcChannels.T2_TIMED, scope);
@@ -76,7 +76,7 @@ const PlainWin: React.FC<{ label: "win1"|"win2" }> = ({ label }) => {
     const ch = label === "win1" ? IpcChannels.T1_TIMED : IpcChannels.T2_TIMED;
     if (!window.api?.registerPush) return;
     window.api.registerPush(ch, scope);
-    const off = window.api.onTimed(label === "win1" ? "t1" : "t2", p => console.log(`${label} timed:`, p));
+    const off = window.api.onTimed(label === "win1" ? "t1" : "t2", p => window.api.toast({ message: `${label} timed: ${p.info}` }));
     return () => { window.api.unregisterPush(ch, scope); off(); };
   }, [label]);
 

--- a/src/types/ipc.d.ts
+++ b/src/types/ipc.d.ts
@@ -5,6 +5,7 @@ declare global {
   interface Window {
     api: {
       onToast(cb: (msg: { message: string; variant?: "default"|"error"|"success"|"warning"|"info" }) => void): () => void;
+      toast(msg: { message: string; variant?: "default"|"error"|"success"|"warning"|"info" }): void;
       onLifecycle(service: "t1"|"t2"|"t3", cb: (ev: LifecycleEvent) => void): () => void;
       onTimed(service: "t1"|"t2"|"t3", cb: (p: TimedPush) => void): () => void;
 


### PR DESCRIPTION
## Summary
- show notistack toasts for timed push callbacks
- expose a `toast` helper in preload API

## Testing
- `npm test` *(fails: Cannot find module '../../src/main/SystemConfig')*

------
https://chatgpt.com/codex/tasks/task_e_68a8b4363bc08323a6233e19a116aa10